### PR TITLE
Improve pane title

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -154,12 +154,12 @@ class CanvasView extends ItemView {
         this.icon = 'chevron-left-square'
 
         this.getCanvas().then((canvas) => {
-            renderView(canvas, 'Canvas the file embedded', this.containerEl);
+            renderView(canvas, 'Canvases embedding the file', this.containerEl);
         });
 
         this.registerEvent(this.app.workspace.on('file-open', () => {
             this.getCanvas().then((canvas) => {
-                renderView(canvas, 'Canvas the file embedded', this.containerEl);
+                renderView(canvas, 'Canvases embedding the file', this.containerEl);
             });
         }));
     }


### PR DESCRIPTION
The pane originally named "Canvas the file embedded" (meaning canvases that are embedded in the file) does not correctly describe the functionality of the pane, which is to display canvases that embed the file. I propose to rename this pane to "Canvases embedding the file" to better reflect what the pane does.